### PR TITLE
fix(tables): prevent false-positive header detection on list cells

### DIFF
--- a/src/tables.js
+++ b/src/tables.js
@@ -55,6 +55,20 @@ function cell(content, node, index) {
   return result
 }
 
+// Check if a line is a valid GFM table separator row
+function isSeparatorRow(line) {
+  // Trim and require it to start and end with a pipe
+  const s = (line || '').trim()
+  if (!s.startsWith('|') || !s.endsWith('|')) return false
+
+  // Each cell must be only dashes, optionally wrapped with colons, with optional spaces
+  // e.g., '---', ':---', '---:', ':---:' (minimum 3 dashes per GFM)
+  const cells = s.split('|').slice(1, -1) // inner cells
+  if (cells.length === 0) return false
+
+  return cells.every(c => /^ *:?-{3,}:? *$/.test(c))
+}
+
 // Check if this is a heading row (enhanced for edge cases)
 function isHeadingRow(tr) {
   if (!tr || !tr.parentNode) return false
@@ -194,7 +208,7 @@ rules.table = {
     if (lines.length === 0) return ''
     
     // Check if we need to add a header row
-    const hasHeaderSeparator = lines.length >= 2 && /\|\s*-+/.test(lines[1])
+    const hasHeaderSeparator = lines.length >= 2 && isSeparatorRow(lines[1])
     
     let result = lines.join('\n')
     

--- a/test/list-in-cell-table.html
+++ b/test/list-in-cell-table.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Table with List in Cell Test</title>
+  </head>
+  <body>
+    <h1>Table with List in Cell Test</h1>
+    <table>
+      <tr>
+        <th scope="row">Prerequisites:</th>
+        <td>Basic HTML familiarity</td>
+      </tr>
+      <tr>
+        <th scope="row">Learning outcomes:</th>
+        <td>
+          <ul>
+            <li>Item one</li>
+            <li>Item two</li>
+          </ul>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/test/tables.test.js
+++ b/test/tables.test.js
@@ -245,6 +245,18 @@ describe('Tables Plugin', () => {
       expect(result).not.toContain('<table')
     })
 
+    it('should handle tables with lists inside cells from HTML file', () => {
+      const htmlPath = join(process.cwd(), 'test', 'list-in-cell-table.html')
+      const html = readFileSync(htmlPath, 'utf8')
+
+      const result = turndownService.turndown(html)
+
+      expect(result).toContain('Table with List in Cell Test')
+      expect(result).toMatch(/^\|\s*---\s*\|\s*---\s*\|$/m)
+      expect(result).toMatch(/\|\s*\* Item one \* Item two\s*\|/)
+      expect(result).not.toContain('<table')
+    })
+
     it('should handle special characters from HTML file', () => {
       const htmlPath = join(process.cwd(), 'test', 'special-characters-table.html')
       const html = readFileSync(htmlPath, 'utf8')

--- a/test/tables.test.js
+++ b/test/tables.test.js
@@ -249,11 +249,14 @@ describe('Tables Plugin', () => {
       const htmlPath = join(process.cwd(), 'test', 'list-in-cell-table.html')
       const html = readFileSync(htmlPath, 'utf8')
 
+      // Force dash bullets to reproduce the original bug
+      turndownService.options.bulletListMarker = '-'
+
       const result = turndownService.turndown(html)
 
       expect(result).toContain('Table with List in Cell Test')
       expect(result).toMatch(/^\|\s*---\s*\|\s*---\s*\|$/m)
-      expect(result).toMatch(/\|\s*\* Item one \* Item two\s*\|/)
+      expect(result).toMatch(/\|\s*- Item one - Item two\s*\|/)
       expect(result).not.toContain('<table')
     })
 


### PR DESCRIPTION
This fixes a false-positive with header-separator detection in the tables plugin (see: #21 )

Previously, the plugin considered any second line matching `|\s*-+` as a header separator. If a cell in the second row contained a list (e.g., `- Item`), the row was incorrectly treated as the delimiter, and the real `| --- | --- |` separator wasn't inserted.

## Changes:
- Replace naive regex with GFM table separator validation
- New `isSeparatorRow()` function validates each cell contains only dashes (3+ per GFM spec)  
- Handles alignment syntax (`:---`, `---:`, `:---:`)

## Testing
- Verified that all existing vite tests still pass
- Added new test for table with row headers and list content in cells, which previously failed to generate separator rows.
- Verified that the new test fails with existing code and passes with the changes.
- Built the plugin and performed real world testing with turndown conversion (via my joplin paste as markdown plugin) and verified that issue #21 now behaves as expected (and also tested with some other misc. tables).
- Spot checked table conversion with/without the change and didn't see any difference in behavior (aside from getting the delimiter in the #21 scenario)

## Before/After
**Before:** Missing separator row
```markdown
| Prerequisites: | Basic HTML familiarity |
| Learning outcomes: | - Item one - Item two |
```

**After:** Proper table format
```markdown
| Prerequisites: | Basic HTML familiarity |
| --- | --- |
| Learning outcomes: | - Item one - Item two |
```
